### PR TITLE
Enhance interface with custom colors and new pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,10 +21,10 @@
     $('#title-main').textContent = translations[lang].title;
     $('#subtitle-main').textContent = translations[lang].subtitle;
     // Navbar text
-    $$('.navbar button').forEach(btn=>{
-      const page = btn.dataset.page;
-      btn.textContent = translations[lang].nav[page];
-    });
+  $$(".navbar button").forEach(btn=>{
+    const page = btn.dataset.page;
+    btn.textContent = (translations[lang].nav && translations[lang].nav[page]) || (translations["en"].nav ? translations["en"].nav[page] : undefined) || btn.textContent;
+  });
     // Home page table headers & title & placeholder
     $('#home-title').textContent = translations[lang].homeTitle;
     const ths = translations[lang].th;
@@ -261,6 +261,13 @@
       setColorful(on);
     };
   }
+function initColorPickers(){
+  const p1 = document.getElementById("accent1-picker");
+  const p2 = document.getElementById("accent2-picker");
+  if(p1){ p1.oninput = ()=>{ document.documentElement.style.setProperty("--accent", p1.value); }; }
+  if(p2){ p2.oninput = ()=>{ document.documentElement.style.setProperty("--accent2", p2.value); }; }
+}
+
 
   // Share page / fact
   function initShare(){
@@ -400,6 +407,7 @@
     initShare();
     initPrint();
     initCopyFact();
+    initColorPickers();
     initResetSearch();
     initObserver();
     initResizeListener();

--- a/index.html
+++ b/index.html
@@ -15,6 +15,12 @@
     <button id="colorful-toggle" aria-label="Toggle Colors" title="Colorful Mode">🎨</button>
     <button id="share-btn" aria-label="Share Page" title="Share">🔗</button>
     <button id="print-btn" aria-label="Print Page" title="Print">🖨️</button>
+    <label class="color-picker-label" id="picker1-label">
+      <input type="color" id="accent1-picker" value="#4a90e2" aria-label="Accent color">
+    </label>
+    <label class="color-picker-label" id="picker2-label">
+      <input type="color" id="accent2-picker" value="#27ae60" aria-label="Secondary color">
+    </label>
     <h1 id="title-main">Niger vs Nigeria</h1>
     <p id="subtitle-main">Discover the beauty, culture and facts about Niger and Nigeria.</p>
     <!-- Language selector -->
@@ -36,6 +42,8 @@
     <button data-page="culture" id="nav-culture">Culture</button>
     <button data-page="quiz" id="nav-quiz">Quiz</button>
     <button data-page="contact" id="nav-contact">Contact</button>
+          <button data-page="economy" id="nav-economy">Economy</button>
+          <button data-page="food" id="nav-food">Cuisine</button>
   </div>
 
   <!-- Main content -->
@@ -134,6 +142,20 @@
           <p><strong>WhatsApp:</strong> <a href="https://wa.me/22796380877" target="_blank">+227 96 38 08 77</a></p>
           <p><strong>Name:</strong> Issoufou Abdou Chéfou</p>
         </div>
+      </div>
+    </div>
+    <!-- Economy Page -->
+    <div class="page" id="page-economy">
+      <div class="card">
+        <h2>Economy</h2>
+        <p>Brief overview of key industries and economic figures for Niger and Nigeria.</p>
+      </div>
+    </div>
+    <!-- Cuisine Page -->
+    <div class="page" id="page-food">
+      <div class="card">
+        <h2>Cuisine</h2>
+        <p>A glimpse into popular dishes and culinary traditions of both nations.</p>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -465,6 +465,26 @@
     outline: 2px dashed var(--accent);
     outline-offset: 2px;
   }
+  /* Color pickers */
+  .color-picker-label {
+    position: absolute;
+    top: 1.4rem;
+    right: 9rem;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+  }
+  #picker2-label {
+    right: 11rem;
+  }
+  .color-picker-label input {
+    width: 100%;
+    height: 100%;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
   /* Colorful mode toggle */
   #colorful-toggle {
     position: absolute;


### PR DESCRIPTION
## Summary
- add color picker inputs so visitors can adjust accents
- allow graceful fallback for navbar translations
- add new `Economy` and `Cuisine` pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ecbc75808331ad4b24074d7aa812